### PR TITLE
Add integration test with GitHub/Table mocks

### DIFF
--- a/SponsorWebhook.Tests/SimpleFunctionContext.cs
+++ b/SponsorWebhook.Tests/SimpleFunctionContext.cs
@@ -1,0 +1,39 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Azure.Functions.Worker.Context.Features;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace SponsorWebhook.Tests;
+
+internal class SimpleFunctionContext : FunctionContext
+{
+    private readonly IInvocationFeatures _features = new SimpleInvocationFeatures();
+
+    public override string InvocationId { get; } = Guid.NewGuid().ToString();
+    public override string FunctionId { get; } = Guid.NewGuid().ToString();
+    public override TraceContext TraceContext { get; } = new SimpleTraceContext();
+    public override BindingContext BindingContext { get; } = null!;
+    public override RetryContext? RetryContext => null;
+    public override IServiceProvider InstanceServices { get; set; } = null!;
+    public override FunctionDefinition FunctionDefinition { get; } = null!;
+    public override IDictionary<object, object> Items { get; set; } = new Dictionary<object, object>();
+    public override IInvocationFeatures Features => _features;
+    public override CancellationToken CancellationToken => CancellationToken.None;
+
+    private class SimpleTraceContext : TraceContext
+    {
+        public override string TraceParent => string.Empty;
+        public override string TraceState => string.Empty;
+    }
+
+    private class SimpleInvocationFeatures : IInvocationFeatures
+    {
+        private readonly Dictionary<Type, object> _storage = new();
+        public void Set<T>(T instance) => _storage[typeof(T)] = instance!;
+        public T? Get<T>() => _storage.TryGetValue(typeof(T), out var v) ? (T)v : default;
+        public IEnumerator<KeyValuePair<Type, object>> GetEnumerator() => _storage.GetEnumerator();
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => _storage.GetEnumerator();
+    }
+}

--- a/SponsorWebhook.Tests/SponsorWebhook.Tests.csproj
+++ b/SponsorWebhook.Tests/SponsorWebhook.Tests.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <AzureFunctionsVersion>v4</AzureFunctionsVersion>
+    <IsPackable>false</IsPackable>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="xunit" Version="2.5.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0" />
+    <PackageReference Include="Moq" Version="4.20.72" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.16.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\SponsorWebhook\SponsorWebhook.csproj" />
+  </ItemGroup>
+</Project>

--- a/SponsorWebhook.Tests/SponsorWebhookTests.cs
+++ b/SponsorWebhook.Tests/SponsorWebhookTests.cs
@@ -1,0 +1,29 @@
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Moq.Protected;
+using Xunit;
+
+namespace SponsorWebhook.Tests;
+
+public class SponsorWebhookTests
+{
+    [Fact]
+    public async Task Run_WritesData_ToMocks()
+    {
+        var context = new SimpleFunctionContext();
+        string payload = "{ \"sponsorship\": { \"sponsor\": { \"login\": \"octocat\" } } }";
+        var request = new TestHttpRequestData(context, payload);
+
+        var mock = new Mock<SponsorFunctions.SponsorWebhook>(NullLoggerFactory.Instance) { CallBase = true };
+        mock.Protected().Setup<Task>("SaveToTableAsync", ItExpr.IsAny<string>(), "octocat", payload)
+            .Returns(Task.CompletedTask).Verifiable();
+        mock.Protected().Setup<Task>("CommitToRepositoryAsync", ItExpr.IsAny<string>(), "octocat")
+            .Returns(Task.CompletedTask).Verifiable();
+
+        await mock.Object.Run(request);
+
+        mock.Protected().Verify("SaveToTableAsync", Times.Once(), ItExpr.IsAny<string>(), "octocat", payload);
+        mock.Protected().Verify("CommitToRepositoryAsync", Times.Once(), ItExpr.IsAny<string>(), "octocat");
+    }
+}

--- a/SponsorWebhook.Tests/TestHttpRequestData.cs
+++ b/SponsorWebhook.Tests/TestHttpRequestData.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Specialized;
+using System.IO;
+using System.Security.Claims;
+using System.Text;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Azure.Functions.Worker.Http;
+
+namespace SponsorWebhook.Tests;
+
+public class TestHttpRequestData : HttpRequestData
+{
+    private readonly MemoryStream _body;
+    private readonly HttpHeadersCollection _headers;
+
+    public TestHttpRequestData(FunctionContext context, string body, string method = "POST", Uri? url = null)
+        : base(context)
+    {
+        _body = new MemoryStream(Encoding.UTF8.GetBytes(body));
+        _headers = new HttpHeadersCollection();
+        Method = method;
+        Url = url ?? new Uri("https://example.com");
+    }
+
+    public override Stream Body => _body;
+    public override HttpHeadersCollection Headers => _headers;
+    public override IReadOnlyCollection<IHttpCookie> Cookies { get; } = Array.Empty<IHttpCookie>();
+    public override IEnumerable<ClaimsIdentity> Identities => Array.Empty<ClaimsIdentity>();
+    public override string Method { get; }
+    public override Uri Url { get; }
+    public override NameValueCollection Query { get; } = new NameValueCollection();
+
+    public override HttpResponseData CreateResponse()
+    {
+        return new TestHttpResponseData(FunctionContext);
+    }
+}

--- a/SponsorWebhook.Tests/TestHttpResponseData.cs
+++ b/SponsorWebhook.Tests/TestHttpResponseData.cs
@@ -1,0 +1,23 @@
+using System;
+using System.IO;
+using System.Net;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Azure.Functions.Worker.Http;
+
+namespace SponsorWebhook.Tests;
+
+public class TestHttpResponseData : HttpResponseData
+{
+    private readonly MemoryStream _body = new MemoryStream();
+
+    public TestHttpResponseData(FunctionContext context) : base(context)
+    {
+        Headers = new HttpHeadersCollection();
+        Cookies = (HttpCookies?)Activator.CreateInstance(typeof(HttpCookies), true)!;
+    }
+
+    public override HttpStatusCode StatusCode { get; set; }
+    public override HttpHeadersCollection Headers { get; set; }
+    public override Stream Body { get => _body; set => _body.SetLength(0); }
+    public override HttpCookies Cookies { get; }
+}

--- a/SponsorWebhook/SponsorWebhook.cs
+++ b/SponsorWebhook/SponsorWebhook.cs
@@ -46,7 +46,7 @@ public class SponsorWebhook
         }
     }
 
-    private record WebhookData(string SponsorLogin, string SponsorGuid, string Payload);
+    protected record WebhookData(string SponsorLogin, string SponsorGuid, string Payload);
 
     private class HttpException : Exception
     {
@@ -57,7 +57,7 @@ public class SponsorWebhook
         }
     }
 
-    private async Task<WebhookData> ReadWebhookAsync(HttpRequestData req)
+    protected virtual async Task<WebhookData> ReadWebhookAsync(HttpRequestData req)
     {
         string body = await new StreamReader(req.Body).ReadToEndAsync();
         var bodyBytes = Encoding.UTF8.GetBytes(body);
@@ -111,7 +111,7 @@ public class SponsorWebhook
         return new WebhookData(sponsorLogin, sponsorGuid, body);
     }
 
-    private async Task SaveToTableAsync(string sponsorGuid, string sponsorLogin, string payload)
+    protected virtual async Task SaveToTableAsync(string sponsorGuid, string sponsorLogin, string payload)
     {
         string tableConn = Environment.GetEnvironmentVariable("TABLE_CONNECTION") ?? string.Empty;
         if (!string.IsNullOrEmpty(tableConn))
@@ -128,7 +128,7 @@ public class SponsorWebhook
         }
     }
 
-    private async Task CommitToRepositoryAsync(string sponsorGuid, string sponsorLogin)
+    protected virtual async Task CommitToRepositoryAsync(string sponsorGuid, string sponsorLogin)
     {
         string token = Environment.GetEnvironmentVariable("GITHUB_TOKEN") ?? string.Empty;
         string repoName = Environment.GetEnvironmentVariable("GITHUB_REPO") ?? string.Empty;


### PR DESCRIPTION
## Summary
- allow subclassing SponsorWebhook methods
- add test project for SponsorWebhook
- include simple FunctionContext and HTTP request/response helpers
- verify GitHub and table methods via Moq

## Testing
- `dotnet build SponsorWebhook.Tests/SponsorWebhook.Tests.csproj -v minimal`
- `dotnet test SponsorWebhook.Tests/SponsorWebhook.Tests.csproj --no-build` *(fails: Azure.Core.dll not found)*

------
https://chatgpt.com/codex/tasks/task_e_688338f9d5608327b2dedec1d3dd98fd